### PR TITLE
Update Ubuntu image for GitHub workflows

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -9,7 +9,7 @@ on: [workflow_dispatch]
 jobs:
     build-docs:
         name: Build docs and push to gh-pages
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
                 python-version: 3.8
             
             - name: Install poetry
-              uses: snok/install-poetry@v1.1.4
+              uses: snok/install-poetry@v1.3.4
               with:
                 version: 1.1.4
                 virtualenvs-create: true

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
                 python-version: 3.8
             
             - name: Install poetry
-              uses: snok/install-poetry@v1.1.2
+              uses: snok/install-poetry@v1.3.4
               with:
                 version: 1.1.5
                 virtualenvs-create: true

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     build-n-publish:
         name: Build and publish to PyPI
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2


### PR DESCRIPTION
[Context](https://github.com/actions/runner-images/issues/6002z) (ubuntu-18.04 is deprecated and [our actions](https://github.com/quant-aq/py-quantaq/actions/runs/6030754907) aren't running anymore)