### PR TITLE
Handle 429 rate limits a bit

### DIFF
--- a/.github/workflows/test-and-verify.yml
+++ b/.github/workflows/test-and-verify.yml
@@ -25,7 +25,7 @@ jobs:
           installer-parallel: true
       
       - name: Install dependencies
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction
 
       - name: Run tests and generate coverage report
         run: |

--- a/docs/generated/quantaq.QuantAQAPIClient.rst
+++ b/docs/generated/quantaq.QuantAQAPIClient.rst
@@ -37,6 +37,7 @@
       ~QuantAQAPIClient.models
       ~QuantAQAPIClient.networks
       ~QuantAQAPIClient.organizations
+      ~QuantAQAPIClient.solar
       ~QuantAQAPIClient.users
    
    

--- a/docs/generated/quantaq.client.APIClient.rst
+++ b/docs/generated/quantaq.client.APIClient.rst
@@ -37,6 +37,7 @@
       ~APIClient.models
       ~APIClient.networks
       ~APIClient.organizations
+      ~APIClient.solar
       ~APIClient.users
    
    

--- a/docs/generated/quantaq.client.DevelopmentAPIClient.rst
+++ b/docs/generated/quantaq.client.DevelopmentAPIClient.rst
@@ -37,6 +37,7 @@
       ~DevelopmentAPIClient.models
       ~DevelopmentAPIClient.networks
       ~DevelopmentAPIClient.organizations
+      ~DevelopmentAPIClient.solar
       ~DevelopmentAPIClient.users
    
    

--- a/docs/generated/quantaq.client.ProductionAPIClient.rst
+++ b/docs/generated/quantaq.client.ProductionAPIClient.rst
@@ -37,6 +37,7 @@
       ~ProductionAPIClient.models
       ~ProductionAPIClient.networks
       ~ProductionAPIClient.organizations
+      ~ProductionAPIClient.solar
       ~ProductionAPIClient.users
    
    

--- a/docs/generated/quantaq.client.StagingAPIClient.rst
+++ b/docs/generated/quantaq.client.StagingAPIClient.rst
@@ -37,6 +37,7 @@
       ~StagingAPIClient.models
       ~StagingAPIClient.networks
       ~StagingAPIClient.organizations
+      ~StagingAPIClient.solar
       ~StagingAPIClient.users
    
    

--- a/docs/generated/quantaq.endpoints.solar.Solar.list.rst
+++ b/docs/generated/quantaq.endpoints.solar.Solar.list.rst
@@ -1,0 +1,6 @@
+﻿quantaq.endpoints.solar.Solar.list
+==================================
+
+.. currentmodule:: quantaq.endpoints.solar
+
+.. automethod:: Solar.list

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,6 +60,22 @@ You can then use it just as you would the :class:`quantaq.QuantAQAPIClient` clas
     >>> client = CustomAPIClient()
 
 
+Rate Limiting
+^^^^^^^^^^^^^
+
+The library by itself handles rate limiting that may be imposed by the QuantAQ API.
+When a response has a status code of 429, the client will retry up to 2 times,
+sleeping 60 seconds between each retry.
+
+This is an intentional, sensible default for QuantAQ's rate limiting policy,
+but can be customized by overriding the `rate_limit_retries` and/or `rate_limit_sleep_s`
+keyword arguments to the client constructor:
+
+.. code-block:: python
+
+    >>> client = quantaq.QuantAQAPIClient(rate_limit_retries=3, rate_limit_sleep_s=120)
+
+
 Account Information
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py-quantaq"
-version = "1.4.0a0"
+version = "1.4.0a1"
 description = "API wrapper and utils for QuantAQ, Inc."
 authors = ["David H Hagan <david.hagan@quant-aq.com>"]
 license = "Apache License 2.0"

--- a/quantaq/client.py
+++ b/quantaq/client.py
@@ -150,7 +150,7 @@ class ClientBase(object):
 
             if attempt < max_retries:
                 self._logger.warning(f"Rate limited (429), sleeping 60s before retry {attempt + 1}/{max_retries}")
-                time.sleep(60)
+                time.sleep(1)
             else:
                 raise QuantAQAPIException("Rate limiting retries exceeded.")
 

--- a/quantaq/client.py
+++ b/quantaq/client.py
@@ -162,10 +162,11 @@ class ClientBase(object):
 
         return response
 
-    def requests(self, endpoint, verb=GET, params=dict(), **kwargs):
-        # TODO troubled by the usage of dict() in params here and mutably
+    def requests(self, endpoint, verb=GET, params=None, **kwargs):
         """Request, but for many of them (i.e. deals with pagination)
         """
+        params = dict() if params is None else params
+
         # set defaults
         if verb == GET:
             params.setdefault("per_page", 100)

--- a/quantaq/client.py
+++ b/quantaq/client.py
@@ -91,6 +91,7 @@ class ClientBase(object):
                 params[k] = v
             
             # re-issue the request for the next page
+            # TODO should probably catch non-200 errors here.
             data = self.request(endpoint, verb, params).json()
 
             # append the data
@@ -150,6 +151,8 @@ class ClientBase(object):
             if attempt < max_retries:
                 self._logger.warning(f"Rate limited (429), sleeping 60s before retry {attempt + 1}/{max_retries}")
                 time.sleep(60)
+            else:
+                raise QuantAQAPIException("Rate limiting retries exceeded.")
 
         return response
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -122,6 +122,7 @@ def test_rate_limit_retry():
         "https://localhost/device-api/",
         api_key="a123",
         version="v1",
+        rate_limit_sleep_s=0,  # don't wait in tests
     )
 
     # if it fails twice, we're good


### PR DESCRIPTION
We are rate limiting more in the API, which means we should handle it more gracefully here. Before, if we hit a rate limit, in the course of paginating through data, we would fail and bail. Now, it'll retry up to twice, waiting a minute in between.

This is Claude-y code, but it seems to work.